### PR TITLE
Config coverage and bug fixes

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ func (cfg *Config) Validate() (errors []error) {
 		errors = append(errors, fmt.Errorf("set FORWARDING_NUMBER environment variable to connect your incoming calls to your phone"))
 	}
 	// If no voicemail file is accessible and no script is set, falls back to generic voicemail prompt
-	if _, err := os.Stat(fullVoicemailPath); os.IsNotExist(err) {
+	if stat, err := os.Stat(fullVoicemailPath); os.IsNotExist(err) || stat.IsDir() {
 		log.Printf("Voicemail file not found, falling back to voice prompt")
 		cfg.VoicemailFile = ""
 		if len(cfg.VoicemailScript) == 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,108 @@
+package main_test
+
+import (
+	"os"
+
+	. "github.com/BTBurke/twilio-voice"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Config", func() {
+	var cfg *Config
+
+	BeforeEach(func() {
+		cfg = &Config{
+			MailgunPublicKey:  "abc123",
+			MailgunSecretKey:  "pancakes",
+			MailgunDomain:     "example.com",
+			ForwardingNumber:  "+15555555",
+			NotificationEmail: "voicemail@example.com",
+		}
+	})
+
+	Describe(".Validate", func() {
+		It("returns empty slice when valid", func() {
+			Expect(cfg.Validate()).To(BeEmpty())
+		})
+
+		It("sets default VoicemailScript when VoicemailFile does not exist", func() {
+			cfg.VoicemailFile = "/path/to/a/nonexistent/file.mp3"
+			cfg.VoicemailScript = ""
+
+			Expect(cfg.Validate()).To(BeEmpty())
+			Expect(cfg.VoicemailScript).To(Equal("Please leave a message"))
+		})
+
+		// FIXME(ivy): blank VoicemailFile succeeds
+		XIt("sets default VoicemailScript when VoicemailFile unspecificed", func() {
+			cfg.VoicemailFile = ""
+			cfg.VoicemailScript = ""
+
+			Expect(cfg.Validate()).To(BeEmpty())
+			Expect(cfg.VoicemailScript).To(Equal("Please leave a message"))
+		})
+
+		It("uses specified VoicemailFile when exists", func() {
+			wd, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg.VoicemailFile = "README.md"
+
+			Expect(cfg.Validate()).To(BeEmpty())
+			Expect(cfg.ServeDirectory).To(Equal(wd + "/"))
+			Expect(cfg.VoiceFileName).To(Equal("README.md"))
+		})
+
+		It("returns error when missing MailgunPublicKey", func() {
+			cfg.MailgunPublicKey = ""
+
+			errs := cfg.Validate()
+			Expect(len(errs)).To(Equal(1))
+			Expect(errs[0]).To(MatchError(
+				MatchRegexp("set.*MAILGUN_PUBLIC_KEY"),
+			))
+		})
+
+		It("returns error when missing MailgunSecretKey", func() {
+			cfg.MailgunSecretKey = ""
+
+			errs := cfg.Validate()
+			Expect(len(errs)).To(Equal(1))
+			Expect(errs[0]).To(MatchError(
+				MatchRegexp("set.*MAILGUN_SECRET_KEY"),
+			))
+		})
+
+		It("returns error when missing MailgunDomain", func() {
+			cfg.MailgunDomain = ""
+
+			errs := cfg.Validate()
+			Expect(len(errs)).To(Equal(1))
+			Expect(errs[0]).To(MatchError(
+				MatchRegexp("set.*MAILGUN_DOMAIN"),
+			))
+		})
+
+		It("returns error when missing NotificationEmail", func() {
+			cfg.NotificationEmail = ""
+
+			errs := cfg.Validate()
+			Expect(len(errs)).To(Equal(1))
+			Expect(errs[0]).To(MatchError(
+				MatchRegexp("set.*NOTIFICATION_EMAIL"),
+			))
+		})
+
+		It("returns error when missing ForwardingNumber", func() {
+			cfg.ForwardingNumber = ""
+
+			errs := cfg.Validate()
+			Expect(len(errs)).To(Equal(1))
+			Expect(errs[0]).To(MatchError(
+				MatchRegexp("set.*FORWARDING_NUMBER"),
+			))
+		})
+	})
+})

--- a/config_test.go
+++ b/config_test.go
@@ -51,10 +51,8 @@ var _ = Describe("Config", func() {
 		}
 
 		whenVoicemailFile("non-existent", "/path/to/a/nonexistent/file.mp3")
-		// FIXME(ivy): succeeds even though VoicemailFile is a directory
-		//whenVoicemailFile("directory", "templates")
-		// FIXME(ivy): blank VoicemailFile succeeds
-		//whenVoicemailFile("unspecified", "")
+		whenVoicemailFile("directory", "templates")
+		whenVoicemailFile("unspecified", "")
 
 		It("uses specified VoicemailFile when exists", func() {
 			wd, err := os.Getwd()

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/BTBurke/twilio-voice"
@@ -27,22 +28,33 @@ var _ = Describe("Config", func() {
 			Expect(cfg.Validate()).To(BeEmpty())
 		})
 
-		It("sets default VoicemailScript when VoicemailFile does not exist", func() {
-			cfg.VoicemailFile = "/path/to/a/nonexistent/file.mp3"
-			cfg.VoicemailScript = ""
+		whenVoicemailFile := func(desc, file string) {
+			Context(fmt.Sprintf(`when VoicemailFile is "%s"`, desc), func() {
+				JustBeforeEach(func() {
+					cfg.VoicemailFile = file
+				})
 
-			Expect(cfg.Validate()).To(BeEmpty())
-			Expect(cfg.VoicemailScript).To(Equal("Please leave a message"))
-		})
+				It("sets default VoicemailScript", func() {
+					cfg.VoicemailScript = ""
 
+					Expect(cfg.Validate()).To(BeEmpty())
+					Expect(cfg.VoicemailScript).To(Equal("Please leave a message"))
+				})
+
+				It("does not override custom VoicemailScript", func() {
+					cfg.VoicemailScript = "What do you want?!"
+
+					Expect(cfg.Validate()).To(BeEmpty())
+					Expect(cfg.VoicemailScript).To(Equal("What do you want?!"))
+				})
+			})
+		}
+
+		whenVoicemailFile("non-existent", "/path/to/a/nonexistent/file.mp3")
+		// FIXME(ivy): succeeds even though VoicemailFile is a directory
+		//whenVoicemailFile("directory", "templates")
 		// FIXME(ivy): blank VoicemailFile succeeds
-		XIt("sets default VoicemailScript when VoicemailFile unspecificed", func() {
-			cfg.VoicemailFile = ""
-			cfg.VoicemailScript = ""
-
-			Expect(cfg.Validate()).To(BeEmpty())
-			Expect(cfg.VoicemailScript).To(Equal("Please leave a message"))
-		})
+		//whenVoicemailFile("unspecified", "")
 
 		It("uses specified VoicemailFile when exists", func() {
 			wd, err := os.Getwd()

--- a/twilio_voice_suite_test.go
+++ b/twilio_voice_suite_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTwilioVoice(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "twilio-voice suite")
+}
+
+var _ = BeforeSuite(func() {
+	log.SetOutput(GinkgoWriter)
+})


### PR DESCRIPTION
Today I bootstrapped a Ginkgo test suite to cover the various edge cases when validating the configuration. In the process of writing the tests however, I discovered and fixed a small bug in the way `VoicemailFile` is validated. When it's blank or points to a directory, it's mistaken for a real, existing file (in the case of a blank filename, `fullVoicemailPath` expands to the working directory).

The fix is to test if `VoicemailFile` is a directory. This has also has the side-effect of fixing the failing test case for a *blank* filename.