### PR TITLE
Generate bindata with go generate

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -1,3 +1,4 @@
+//go:generate go-bindata templates
 package main
 
 import (


### PR DESCRIPTION
This pull request adds a `//go:generate ...` line to `notify.go`, making it convenient to regenerate bindata for the `templates/` directory with the `go generate` subcommand.