### PR TITLE
Fix test suite in unconfigured environments

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,12 +22,13 @@ func init() {
 		VoicemailScript:   os.Getenv("VOICEMAIL_SCRIPT"),
 		VoicemailFile:     os.Getenv("VOICEMAIL_FILE"),
 	}
-	if errs := cfg.Validate(); len(errs) > 0 {
-		log.Fatalf("%v", errs)
-	}
 }
 
 func main() {
+	if errs := cfg.Validate(); len(errs) > 0 {
+		log.Fatalf("%v", errs)
+	}
+
 	log.Printf("Forwarding calls to %s\n", cfg.ForwardingNumber)
 	log.Printf("Voicemail notifications will be sent to %s\n", cfg.NotificationEmail)
 


### PR DESCRIPTION
In environments where no config variables are set, the test suite fails with:

    2017/07/06 18:55:25 Voicemail file not found, falling back to voice prompt
    2017/07/06 18:55:25 [set MAILGUN_PUBLIC_KEY, MAILGUN_SECRET_KEY, MAILGUN_DOMAIN environment variables to receive voicemail notifications set NOTIFICATION_EMAIL environment variable to receive voicemail notifications set FORWARDING_NUMBER environment variable to connect your incoming calls to your phone]
    exit status 1
    FAIL    github.com/BTBurke/twilio-voice 0.012s

This is fixed by moving config validation to `main` instead of `init`, allowing the test suite to execute normally.